### PR TITLE
Use devmode when running the tests

### DIFF
--- a/vendor/telling-stories/player-mode.css
+++ b/vendor/telling-stories/player-mode.css
@@ -54,24 +54,3 @@
   75% { opacity: .5; }
   100% { opacity: 1; }
 }
-
-/* Reset */
-.telling-stories #qunit {
-  display: none;
-}
-
-.telling-stories #ember-testing {
-  zoom: 1;
-  transform: none;
-  width: 100%;
-}
-
-.telling-stories #ember-testing-container {
-  width: auto;
-  height: 100%;
-  border-style: none;
-  margin: 0;
-  overflow: visible;
-  top: 0;
-  right: 0;
-}

--- a/vendor/telling-stories/qunit-configuration.js
+++ b/vendor/telling-stories/qunit-configuration.js
@@ -6,6 +6,7 @@ jQuery(function() {
     });
 
     if (window.QUnit.urlParams.tellingStories) {
+      window.QUnit.urlParams.devmode = true;
       $('body').addClass('telling-stories');
     }
   }


### PR DESCRIPTION
Instead of hidden all qunit stuff with css now it uses `devmode` option.

Here is what devmode does:

https://github.com/ember-cli/ember-cli-qunit/pull/120/files