### PR TITLE
Fix white screen issue

### DIFF
--- a/addon/animation.js
+++ b/addon/animation.js
@@ -164,11 +164,10 @@ function scrollToElement($element, delay = 0, duration = SCROLL_SPEED) {
 function finish() {
   $('body')
     .delay(4000)
-    .fadeOut(3000);
+    .fadeOut(3000, () => $('body').show());
 
   return sleep(7000).then(function() {
     logContainer().html('');
-    $('body').show();
   });
 }
 


### PR DESCRIPTION
There is a race condition in the finish method of animation.js between the delay + fadeOut jquery methods and the sleep method. Sometimes the sleep method resolves before the fadeOut finish causing the `body` html element to keep the `display:none` css rules.

fixes #35 